### PR TITLE
chore: update Node.js to v.24, update puppeteer

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -10,9 +10,9 @@ name: Automatic PR Labeler
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [ develop ]
     types:
-      [opened, reopened, synchronize]
+      [ opened, reopened, synchronize ]
 
 permissions:
   pull-requests: write
@@ -24,7 +24,7 @@ jobs:
     if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Execute assign labels"
         id: action-assign-labels

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   delete-dist-tag:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@feature/nodejs24
+    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@main

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   delete-dist-tag:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@main
+    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@feature/nodejs24

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-frontend-ci-workflow:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@feature/nodejs24
+    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@main

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-frontend-ci-workflow:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@main
+    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@feature/nodejs24

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -2,7 +2,7 @@ name: PR Auto-Assignment
 run-name: "Assigning reviewers for PR #${{ github.event.pull_request.number }}"
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
     branches:
       - main
 
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: "Checkout Repository"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -18,6 +18,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Get the common linters configuration"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: main # fix/superlinter-config
         repository: netcracker/.github
         sparse-checkout: |
           config/linters
     - name: "Upload the common linters configsuration"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: linter-config
         path: "${{ github.workspace }}/config"
@@ -55,12 +55,12 @@ jobs:
       statuses: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
     - name: "Get the common linters configuration"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       id: download
       with:
         name: linter-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcracker/qubership-apihub-jest-chrome-in-docker-environment",
-  "version": "2.0.0-dev.0",
+  "version": "2.0.1-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcracker/qubership-apihub-jest-chrome-in-docker-environment",
-      "version": "2.0.0-dev.0",
+      "version": "2.0.1-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
         "colors": "1.4.0",
@@ -20,11 +20,11 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "jest-environment-puppeteer": "< 8.0.0",
-        "puppeteer": "21.11.0"
+        "jest-environment-puppeteer": ">= 7.0.0",
+        "puppeteer": ">= 19.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@netcracker/qubership-apihub-jest-chrome-in-docker-environment",
-  "version": "2.0.1-dev.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@netcracker/qubership-apihub-jest-chrome-in-docker-environment",
-      "version": "2.0.1-dev.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "colors": "1.4.0",
@@ -14,7 +14,7 @@
         "find-node-modules": "2.1.3"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "2.2.2",
+        "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
         "@types/find-node-modules": "2.1.2",
         "@types/jest-environment-puppeteer": "5.0.6",
         "typescript": "5.3.3"
@@ -171,23 +171,28 @@
       "license": "MIT"
     },
     "node_modules/@netcracker/qubership-apihub-npm-gitflow": {
-      "version": "2.2.2",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-npm-gitflow/2.2.2/b74c14f247c021c2bf5ccb9962af226a1a5fdbcb",
-      "integrity": "sha512-0FD0Zy9aVricUGRH3rlLBT1r+KWEXV1w6/1K9PR0Rrx8azNBtih6nDUD8NbTraQE7AfLroPiCK4R8VoOGLSY4w==",
+      "version": "3.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-npm-gitflow/3.1.1/bb451b4e983f249a7e45e29769e6aa0b9d736fe9",
+      "integrity": "sha512-UV8KqfTRgSKcGswg2SbFmgbfDx0N2HTkaT3yTE8JGo44+P+mBFu3IPGPDsn2yzMLkyJBgOLgyaXdmVeY1G+zuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "command-line-args": "^5.0.2",
         "edit-json-file": "^1.0.8",
         "semver": "^5.5.1",
-        "simple-git": "^3.18.0",
+        "simple-git": "^3.27.0",
         "time-stamp": "^2.0.0"
       },
       "bin": {
+        "bugfix-finish": "bin/bugfix-finish.js",
+        "bugfix-start": "bin/bugfix-start.js",
         "feature-finish": "bin/feature-finish.js",
         "feature-start": "bin/feature-start.js",
+        "hotfix-finish": "bin/hotfix-finish.js",
+        "hotfix-start": "bin/hotfix-start.js",
         "release-finish": "bin/release-finish.js",
-        "release-start": "bin/release-start.js"
+        "release-start": "bin/release-start.js",
+        "update-lock-file": "bin/update-lock-file.js"
       }
     },
     "node_modules/@puppeteer/browsers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       },
       "peerDependencies": {
         "jest-environment-puppeteer": ">= 11.0.0",
-        "puppeteer": ">= 19.0.0"
+        "puppeteer": ">= 22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -191,48 +191,39 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
+      "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
       "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=10"
       }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -267,6 +258,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@types/find-node-modules": {
@@ -337,6 +329,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -344,9 +337,10 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 14"
@@ -390,6 +384,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
@@ -428,42 +423,122 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "peer": true
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/bare-events": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
         }
-      ],
-      "peer": true
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
@@ -479,34 +554,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
@@ -550,13 +602,14 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
-      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -579,6 +632,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -673,15 +727,6 @@
         }
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cwd": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
@@ -700,13 +745,16 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -734,6 +782,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
@@ -762,9 +811,10 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1232444",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
-      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/dunder-proto": {
@@ -798,12 +848,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "once": "^1.4.0"
@@ -880,6 +932,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -896,6 +949,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
@@ -917,6 +971,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
@@ -930,6 +985,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -939,9 +995,20 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/expand-tilde": {
@@ -958,6 +1025,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -978,12 +1046,14 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
@@ -1211,6 +1281,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -1259,6 +1330,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -1271,9 +1343,10 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -1390,6 +1463,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -1403,6 +1477,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -1411,26 +1486,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peer": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -1453,14 +1508,11 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -1482,6 +1534,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -1884,12 +1937,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "peer": true
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -1942,6 +1989,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2009,12 +2057,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "peer": true
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/ms": {
@@ -2022,38 +2065,20 @@
       "license": "MIT"
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "wrappy": "1"
@@ -2070,9 +2095,10 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.1.0.tgz",
-      "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -2092,6 +2118,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
@@ -2152,6 +2179,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/picocolors": {
@@ -2196,6 +2224,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -2216,19 +2245,20 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
         "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
+        "pac-proxy-agent": "^7.1.0",
         "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -2238,12 +2268,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -2251,63 +2283,45 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
-      "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
-      "deprecated": "< 22.8.2 is no longer supported",
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.0.tgz",
+      "integrity": "sha512-DRnMFz+J3s4lFUQcjqKl0/7h0jzlCZuUFU9lNjtKrnMl5WI1RwCaIItpHVu9empuPyUreYueN0sUW3/pnfdqsg==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
-        "cosmiconfig": "9.0.0",
-        "puppeteer-core": "21.11.0"
+        "@puppeteer/browsers": "2.13.1",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.0",
+        "typed-query-selector": "^2.12.2"
       },
       "bin": {
-        "puppeteer": "lib/esm/puppeteer/node/cli.js"
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
-      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
+      "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.8",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1232444",
-        "ws": "8.16.0"
+        "@puppeteer/browsers": "2.13.1",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
       }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "peer": true
     },
     "node_modules/r-json": {
       "version": "1.3.0",
@@ -2326,6 +2340,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2431,6 +2446,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 6.0.0",
@@ -2438,12 +2454,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -2455,6 +2472,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -2469,6 +2487,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
       "engines": {
@@ -2489,12 +2508,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "peer": true
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "license": "MIT",
@@ -2506,22 +2519,22 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
+        "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2536,6 +2549,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2555,41 +2569,52 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "peer": true
     },
     "node_modules/time-stamp": {
       "version": "2.2.0",
@@ -2608,12 +2633,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "peer": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -2638,6 +2657,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/typescript": {
       "version": "5.3.3",
       "devOptional": true,
@@ -2658,25 +2684,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "license": "MIT"
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
-      "peer": true
     },
     "node_modules/w-json": {
       "version": "1.3.10",
@@ -2703,21 +2713,12 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0",
       "peer": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -2733,6 +2734,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2750,12 +2752,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
@@ -2777,6 +2781,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -2786,6 +2791,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -2804,6 +2810,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -2813,10 +2820,21 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "find-node-modules": "2.1.3"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "2.2.2",
+        "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
         "@types/find-node-modules": "2.1.2",
         "@types/jest-environment-puppeteer": "5.0.6",
         "typescript": "5.3.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "find-node-modules": "2.1.3"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
+        "@netcracker/qubership-apihub-npm-gitflow": "2.2.2",
         "@types/find-node-modules": "2.1.2",
         "@types/jest-environment-puppeteer": "5.0.6",
         "typescript": "5.3.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "jest-environment-puppeteer": ">= 7.0.0",
+        "jest-environment-puppeteer": ">= 11.0.0",
         "puppeteer": ">= 19.0.0"
       }
     },
@@ -46,19 +46,58 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "peer": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@jest/environment": {
@@ -195,27 +234,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "peer": true
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "peer": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "peer": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "peer": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -237,6 +255,13 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -353,15 +378,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "peer": true
     },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "dev": true,
@@ -386,17 +402,29 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -484,6 +512,20 @@
         "node": "*"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -547,22 +589,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone-deep": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-      "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-      "peer": true,
-      "dependencies": {
-        "for-own": "^0.1.3",
-        "is-plain-object": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "lazy-cache": "^1.0.3",
-        "shallow-clone": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
@@ -588,6 +614,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -611,12 +638,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/cosmiconfig": {
@@ -658,6 +686,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/cwd/-/cwd-0.10.0.tgz",
       "integrity": "sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "find-pkg": "^0.1.2",
@@ -691,6 +720,16 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -709,6 +748,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -726,6 +766,21 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
       "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/edit-json-file": {
       "version": "1.8.0",
@@ -770,6 +825,55 @@
       "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -840,15 +944,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "license": "MIT",
@@ -912,6 +1007,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
       "integrity": "sha512-mBxmNbVyjg1LQIIpgO8hN+ybWBgDQK8qjht+EbrTCGmmPV/sc7RF1i9stPTD6bpvXZywBdrwRYxhSdJv867L6A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "fs-exists-sync": "^0.1.0",
@@ -925,6 +1021,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.1"
@@ -937,6 +1034,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "global-prefix": "^0.1.4",
@@ -950,6 +1048,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha512-gOPiyxcD9dJGCEArAhF4Hd0BAqvAe/JzERP7tYumE4yIkmIedPUVXcJFWbV3/p/ovIIvKjkrTk+f1UVkq7vvbw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.0",
@@ -965,6 +1064,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -974,6 +1074,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha512-QxMPqI6le2u0dCLyiGzgy92kjkkL6zO0XyvHzjdTNH3zM6e5Hz3BwG6+aEyNgiQ5Xz6PwTwgQEj3U50dByPKIA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "expand-tilde": "^1.2.2",
@@ -995,6 +1096,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
       "integrity": "sha512-0rnQWcFwZr7eO0513HahrWafsc3CTFioEB7DRiEYCUM/70QXSY8f3mCST17HXLcPvEhzH/Ty/Bxd72ZZsr/yvw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "find-file-up": "^0.1.2"
@@ -1004,14 +1106,15 @@
       }
     },
     "node_modules/find-process": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
-      "integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.11.tgz",
+      "integrity": "sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chalk": "^4.0.0",
-        "commander": "^5.1.0",
-        "debug": "^4.1.1"
+        "chalk": "~4.1.2",
+        "commander": "^12.1.0",
+        "loglevel": "^1.9.2"
       },
       "bin": {
         "find-process": "bin/find-process.js"
@@ -1047,15 +1150,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -1066,35 +1170,17 @@
         }
       }
     },
-    "node_modules/for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-      "peer": true,
-      "dependencies": {
-        "for-in": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1105,9 +1191,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -1117,6 +1214,45 @@
       "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -1174,6 +1310,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "license": "ISC"
@@ -1183,6 +1332,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -1280,21 +1471,6 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "peer": true
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "peer": true
-    },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "license": "MIT",
@@ -1330,6 +1506,7 @@
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -1359,6 +1536,7 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1370,21 +1548,22 @@
       "license": "MIT"
     },
     "node_modules/jest-dev-server": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-7.0.1.tgz",
-      "integrity": "sha512-0GXo3KEtPU+WaDNYYZIieS9wrdNk5CwpB7oi2tiMIUxTKf3CzWFy6zZE/NN6TgAdxUqjFg7IzZIOBibczzGalA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-11.0.0.tgz",
+      "integrity": "sha512-a54rw3uEzsPckyiXo2rPji9R/5z0d0qhXtru+NwCP8cDxOFk/BIP9PNgmcLh0DU8UTl8s6Lg1u+ri5uQsTJTmw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.7",
         "prompts": "^2.4.2",
-        "spawnd": "^7.0.0",
+        "spawnd": "^11.0.0",
         "tree-kill": "^1.2.2",
-        "wait-on": "^7.0.1"
+        "wait-on": "^8.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/jest-environment-node": {
@@ -1404,19 +1583,20 @@
       }
     },
     "node_modules/jest-environment-puppeteer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-7.0.1.tgz",
-      "integrity": "sha512-ZfNK2jfY4Ru7WQW9aq/WStkyf6I74Y141j1FTGiZtKfj6xh058N+vtWnt7o1yw3SOumrIAL9lMdKWZxWZRVHuA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-11.0.0.tgz",
+      "integrity": "sha512-BJR+k19/awJmXVc5IJ3VY+tho0888PvHAp16D+DP/ezRL84bgg4ggc1Q3mfa85DI+Nw9hgTme3pt0X5F7CWxmg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
-        "cwd": "^0.10.0",
-        "jest-dev-server": "^7.0.1",
-        "jest-environment-node": "^29.4.1",
-        "merge-deep": "^3.0.3"
+        "cosmiconfig": "^8.3.6",
+        "deepmerge": "^4.3.1",
+        "jest-dev-server": "^11.0.0",
+        "jest-environment-node": "^29.7.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/jest-environment-puppeteer/node_modules/@jest/environment": {
@@ -1505,6 +1685,33 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-puppeteer/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-puppeteer/node_modules/jest-environment-node": {
@@ -1643,16 +1850,22 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-tokens": {
@@ -1683,34 +1896,14 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "peer": true
     },
-    "node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "peer": true,
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -1720,15 +1913,30 @@
       "peer": true
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
@@ -1739,23 +1947,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge": {
       "version": "2.1.1",
       "license": "MIT"
-    },
-    "node_modules/merge-deep": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
-      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-      "peer": true,
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "clone-deep": "^0.2.4",
-        "kind-of": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -1772,6 +1976,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -1781,6 +1986,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
@@ -1793,6 +1999,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1803,28 +2010,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "peer": true
-    },
-    "node_modules/mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-      "peer": true,
-      "dependencies": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mixin-object/node_modules/for-in": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-      "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -1878,6 +2063,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1952,6 +2138,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -2009,6 +2205,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "kleur": "^3.0.3",
@@ -2155,9 +2352,10 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -2188,47 +2386,18 @@
         "node": ">=11.0"
       }
     },
-    "node_modules/shallow-clone": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-      "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-      "peer": true,
-      "dependencies": {
-        "is-extendable": "^0.1.1",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "mixin-object": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shallow-clone/node_modules/kind-of": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-      "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-      "peer": true,
-      "dependencies": {
-        "is-buffer": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shallow-clone/node_modules/lazy-cache": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-      "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "peer": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-git": {
       "version": "3.27.0",
@@ -2248,6 +2417,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/slash": {
@@ -2306,17 +2476,17 @@
       }
     },
     "node_modules/spawnd": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-7.0.0.tgz",
-      "integrity": "sha512-TU/M4qYmigdeET4HTR7l9nqySTTvStWM6rW8QyixXRxWn90E718y5Q31ZVXyG7VEqT6oo6EUvE9zk4rGU39HbA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-11.0.0.tgz",
+      "integrity": "sha512-brBHv9HYi8lwNvbI7X52NDZe4yAdsQwvr81b/r98LaN82LzeEnQ0L6YXBvG25zhgWRadTwB+4GsUu9NrNQcVzw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "exit": "^0.1.2",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "tree-kill": "^1.2.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/sprintf-js": {
@@ -2449,6 +2619,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
       "peer": true,
       "bin": {
         "tree-kill": "cli.js"
@@ -2513,16 +2684,17 @@
       "license": "MIT"
     },
     "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
+        "axios": "^1.12.1",
+        "joi": "^18.0.1",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "bin": {
         "wait-on": "bin/wait-on"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "jest-environment-puppeteer": ">= 11.0.0",
-    "puppeteer": ">= 19.0.0"
+    "puppeteer": ">= 22.0.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release-finish": "release-finish"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-npm-gitflow": "2.2.2",
+    "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
     "@types/find-node-modules": "2.1.2",
     "@types/jest-environment-puppeteer": "5.0.6",
     "typescript": "5.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netcracker/qubership-apihub-jest-chrome-in-docker-environment",
-  "version": "2.0.1-dev.0",
+  "version": "2.0.1",
   "description": "",
   "main": "dist/lib/index.js",
   "type": "commonjs",
@@ -13,7 +13,7 @@
     "release-finish": "release-finish"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
+    "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
     "@types/find-node-modules": "2.1.2",
     "@types/jest-environment-puppeteer": "5.0.6",
     "typescript": "5.3.3"

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "find-node-modules": "2.1.3"
   },
   "peerDependencies": {
-    "jest-environment-puppeteer": "< 8.0.0",
-    "puppeteer": "21.11.0"
+    "jest-environment-puppeteer": ">= 7.0.0",
+    "puppeteer": ">= 19.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "find-node-modules": "2.1.3"
   },
   "peerDependencies": {
-    "jest-environment-puppeteer": ">= 7.0.0",
+    "jest-environment-puppeteer": ">= 11.0.0",
     "puppeteer": ">= 19.0.0"
   },
   "engines": {

--- a/src/lib/core/defaults.ts
+++ b/src/lib/core/defaults.ts
@@ -35,7 +35,7 @@ export function getHostCheckPort(){
     return process.env.HOST_CHECK_PORT ? Number(process.env.HOST_CHECK_PORT) : 9009
 }
 export function getConnectToChromeMaxAttempts(){
-    return process.env.CONNECT_TO_CHROME_MAX_ATTEMPTS ? Number(process.env.CONNECT_TO_CHROME_MAX_ATTEMPTS) : 10
+    return process.env.CONNECT_TO_CHROME_MAX_ATTEMPTS ? Number(process.env.CONNECT_TO_CHROME_MAX_ATTEMPTS) : 30
 }
 export function getConnectToChromeRetryIntervals(){
     return process.env.CONNECT_TO_CHROME_RETRY_INTERVAL ? Number(process.env.CONNECT_TO_CHROME_RETRY_INTERVAL) : 2000

--- a/src/lib/core/defaults.ts
+++ b/src/lib/core/defaults.ts
@@ -19,6 +19,7 @@ import os from "os"
 
 export const DOCKER_CONTAINER_NAME = "jest-chrome-container"
 export const CHROME_PORT = 9222
+export const CHROME_INTERNAL_PORT = 9223
 
 const isWindows = os.platform() === "win32"
 

--- a/src/lib/core/defaults.ts
+++ b/src/lib/core/defaults.ts
@@ -48,9 +48,6 @@ export function getNodeBinaryCLIPath() {
     return `${isWindows ? "\"" : `'`}${getNodeBinary()}${isWindows ? "\"" : `'`}`
 }
 
-const isHostMachine = os.platform() === "win32"
-const userDirectory = isHostMachine ? os.tmpdir() + "-" + Math.random() : "" // to avoid getting system browser
-
 /**
  * https://www.browserless.io/docs/chrome-flags
  * https://www.chromium.org/developers/how-tos/run-chromium-with-flags/
@@ -68,8 +65,6 @@ export const DEFAULT_CHROME_FLAGS: ChromeArg[] = [
     "--disable-gpu",
     "--disable-gpu-compositing",
     "--disable-gpu-rasterization",
-    "--remote-debugging-address=0.0.0.0",
-    `--remote-debugging-port=${CHROME_PORT}`,
     "--disable-resize-lock=true",
     "--disable-background-networking",
     "--disable-client-side-phishing-detection",
@@ -96,7 +91,6 @@ export const DEFAULT_CHROME_FLAGS: ChromeArg[] = [
     "--disable-search-engine-choice-screen",
     "--simulate-outdated-no-au=\"Tue, 31 Dec 2099 23:59:59 GMT\"",
     "--start-maximized",
-    ...(userDirectory ? [`--user-data-dir=${userDirectory}` satisfies ChromeArg] : []),
     // Candidates for overriding:
     "--headless=true",
     "--window-size=1800,1000",

--- a/src/lib/core/defaults.ts
+++ b/src/lib/core/defaults.ts
@@ -21,6 +21,14 @@ export const DOCKER_CONTAINER_NAME = "jest-chrome-container"
 export const CHROME_PORT = 9222
 export const CHROME_INTERNAL_PORT = 9223
 
+export function workerExternalPort(workerIndex: number): number {
+  return CHROME_PORT + workerIndex * 2
+}
+
+export function workerInternalPort(workerIndex: number): number {
+  return CHROME_INTERNAL_PORT + workerIndex * 2
+}
+
 const isWindows = os.platform() === "win32"
 
 export function getHostCheckPort(){

--- a/src/lib/core/docker-chrome.ts
+++ b/src/lib/core/docker-chrome.ts
@@ -16,7 +16,7 @@
 
 import os from "os"
 import { bgYellow, black, green, red, yellow } from "colors"
-import { CHROME_PORT, CONSOLE_PREFIX, DOCKER_CONTAINER_NAME, getConnectToChromeMaxAttempts, getConnectToChromeRetryIntervals, getDockerBinaryCLIPath, getHostCheckPort } from "./defaults"
+import { CHROME_INTERNAL_PORT, CHROME_PORT, CONSOLE_PREFIX, DOCKER_CONTAINER_NAME, getConnectToChromeMaxAttempts, getConnectToChromeRetryIntervals, getDockerBinaryCLIPath, getHostCheckPort } from "./defaults"
 import { runCommand } from "./run-command"
 import { ChromeArg } from "../index.types"
 import { dockerContainerIpAddress, getDockerHostIpAddress, getHostnameIpAddress, ping } from "./utils"
@@ -53,6 +53,14 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
     // if host OS is linux:   docker run ... sh -c '/bin/google-chrome --arg1="a b" "--arg1"'
     const preparedFlags = flags.map(f => f.trim().replace(/^["']|["']$|(?<==)["']/g, isWindows ? `'` : `"`))
     if (headless) {
+      // Chrome 113+ ignores --remote-debugging-address=0.0.0.0 and always binds to 127.0.0.1
+      // for security reasons (https://issues.chromium.org/issues/40261787).
+      // Workaround: Chrome listens on 127.0.0.1:CHROME_INTERNAL_PORT, socat forwards
+      // 0.0.0.0:CHROME_PORT → 127.0.0.1:CHROME_INTERNAL_PORT so that the port is
+      // accessible from outside the container via Podman/Docker port mapping.
+      const chromeCmd = `/bin/google-chrome ${preparedFlags.join(" ")}`
+      const socatCmd = `socat TCP-LISTEN:${CHROME_PORT},fork,reuseaddr,bind=0.0.0.0 TCP:127.0.0.1:${CHROME_INTERNAL_PORT}`
+      const containerCmd = `${socatCmd} & ${chromeCmd}`
       chromeContainerId = (await runCommand(getDockerBinaryCLIPath(), [
         "run",
         "-p", `${CHROME_PORT}:${CHROME_PORT}`,
@@ -61,7 +69,7 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
         process.env.DOCKER_IMAGE!,
         "sh",
         "-c",
-        `${isWindows ? "\"" : `'`}/bin/google-chrome ${preparedFlags.join(" ")}${isWindows ? "\"" : `'`}`
+        `${isWindows ? "\"" : `'`}${containerCmd}${isWindows ? "\"" : `'`}`
       ])).out.trim();
       await new Promise((res) => {
         setTimeout(() => {

--- a/src/lib/core/docker-chrome.ts
+++ b/src/lib/core/docker-chrome.ts
@@ -16,7 +16,7 @@
 
 import os from "os"
 import { bgYellow, black, green, red, yellow } from "colors"
-import { CHROME_INTERNAL_PORT, CHROME_PORT, CONSOLE_PREFIX, DOCKER_CONTAINER_NAME, getConnectToChromeMaxAttempts, getConnectToChromeRetryIntervals, getDockerBinaryCLIPath, getHostCheckPort } from "./defaults"
+import { CHROME_PORT, CONSOLE_PREFIX, DOCKER_CONTAINER_NAME, getConnectToChromeMaxAttempts, getConnectToChromeRetryIntervals, getDockerBinaryCLIPath, getHostCheckPort, workerExternalPort, workerInternalPort } from "./defaults"
 import { runCommand } from "./run-command"
 import { ChromeArg } from "../index.types"
 import { dockerContainerIpAddress, getDockerHostIpAddress, getHostnameIpAddress, ping } from "./utils"
@@ -27,43 +27,71 @@ export type DockerUpResult = {
   containerId: string
   ipAddress: string
   hostIpAddress: string
-  webSocketUri: string
+  webSocketUris: string[]
   headless: boolean
 }
 
 const CONNECT_TIMEOUT = 3000
+const CONTAINER_READY_POLL_MS = 300
+const CONTAINER_READY_MAX_ATTEMPTS = 10
 const CDP_WEBSOCKET_ENDPOINT_REGEX = /^DevTools listening on (ws:\/\/.*)$/m;
 
 const isWindows = os.platform() === "win32"
 
-const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
+async function waitForContainerRunning(containerId: string): Promise<void> {
+  for (let i = 0; i < CONTAINER_READY_MAX_ATTEMPTS; i++) {
+    const { out } = await runCommand(getDockerBinaryCLIPath(), [
+      "inspect", "-f", `"{{.State.Status}}"`, containerId
+    ])
+    if (out.trim().replace(/"/g, "") === "running") return
+    await new Promise(r => setTimeout(r, CONTAINER_READY_POLL_MS))
+  }
+  throw new Error(`${CONSOLE_PREFIX} Container ${containerId} did not reach 'running' state`)
+}
+
+const dockerUp = async (flags: ChromeArg[], workersCount: number): Promise<DockerUpResult> => {
   const headlessArg = flags.find(f => f.trim().startsWith("--headless"))?.split("=");
   const headless = headlessArg && ["shell", "new", "true"].includes(headlessArg[1])
 
   console.log(bgYellow(black(`${CONSOLE_PREFIX} Headless mode is${headless ? " " : " not "}enabled.`)));
 
   try {
-    console.log(green(`${CONSOLE_PREFIX} Starting Docker container...`));
+    console.log(green(`${CONSOLE_PREFIX} Starting Docker container with ${workersCount} Chrome instance(s)...`));
 
-    let chromeContainerId;
-    let ipAddress;
-    let gateway;
-    let webSocketUri;
+    let chromeContainerId: string;
+    let ipAddress: string;
+    let gateway: string;
+    let webSocketUris: string[];
     // if host OS is windows: docker run ... sh -c "/bin/google-chrome --arg1='a b' '--arg1'"
     // if host OS is linux:   docker run ... sh -c '/bin/google-chrome --arg1="a b" "--arg1"'
     const preparedFlags = flags.map(f => f.trim().replace(/^["']|["']$|(?<==)["']/g, isWindows ? `'` : `"`))
     if (headless) {
       // Chrome 113+ ignores --remote-debugging-address=0.0.0.0 and always binds to 127.0.0.1
       // for security reasons (https://issues.chromium.org/issues/40261787).
-      // Workaround: Chrome listens on 127.0.0.1:CHROME_INTERNAL_PORT, socat forwards
-      // 0.0.0.0:CHROME_PORT → 127.0.0.1:CHROME_INTERNAL_PORT so that the port is
+      // Workaround: Chrome listens on 127.0.0.1:internalPort, socat forwards
+      // 0.0.0.0:externalPort → 127.0.0.1:internalPort so that the port is
       // accessible from outside the container via Podman/Docker port mapping.
-      const chromeCmd = `/bin/google-chrome ${preparedFlags.join(" ")}`
-      const socatCmd = `socat TCP-LISTEN:${CHROME_PORT},fork,reuseaddr,bind=0.0.0.0 TCP:127.0.0.1:${CHROME_INTERNAL_PORT}`
-      const containerCmd = `${socatCmd} & ${chromeCmd}`
+      const chromeCmds: string[] = []
+      const socatCmds: string[] = []
+      const portMappings: string[] = []
+      for (let i = 0; i < workersCount; i++) {
+        const externalPort = workerExternalPort(i)
+        const internalPort = workerInternalPort(i)
+        const workerFlags = preparedFlags
+          .map(f => f.startsWith("--remote-debugging-port=") ? `--remote-debugging-port=${internalPort}` : f)
+          .filter(f => !f.startsWith("--user-data-dir="))
+        workerFlags.push(`--user-data-dir=/tmp/chrome-profile-${i}`)
+        chromeCmds.push(`/bin/google-chrome ${workerFlags.join(" ")}`)
+        socatCmds.push(`socat TCP-LISTEN:${externalPort},fork,reuseaddr,bind=0.0.0.0 TCP:127.0.0.1:${internalPort}`)
+        portMappings.push("-p", `${externalPort}:${externalPort}`)
+      }
+      // All socats in background, all chromes except last in background, last in foreground
+      const bgCmds = [...socatCmds, ...chromeCmds.slice(0, -1)].map(c => `${c} &`).join(" ")
+      const containerCmd = `${bgCmds} ${chromeCmds[chromeCmds.length - 1]}`
+
       chromeContainerId = (await runCommand(getDockerBinaryCLIPath(), [
         "run",
-        "-p", `${CHROME_PORT}:${CHROME_PORT}`,
+        ...portMappings,
         "-d",
         "--name", DOCKER_CONTAINER_NAME,
         process.env.DOCKER_IMAGE!,
@@ -71,12 +99,8 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
         "-c",
         `${isWindows ? "\"" : `'`}${containerCmd}${isWindows ? "\"" : `'`}`
       ])).out.trim();
-      await new Promise((res) => {
-        setTimeout(() => {
-          res(null)
-        }, 2000);
-      })
 
+      await waitForContainerRunning(chromeContainerId)
       ipAddress = await dockerContainerIpAddress(chromeContainerId, CHROME_PORT, CONNECT_TIMEOUT)
       gateway = await getDockerHostIpAddress(chromeContainerId, getHostCheckPort(), CONNECT_TIMEOUT)
 
@@ -85,12 +109,18 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
       let maxAttempts = getConnectToChromeMaxAttempts();
       let retryInterval = getConnectToChromeRetryIntervals();
 
-      webSocketUri = (
-        await contactChrome(`http://${ipAddress}:${CHROME_PORT}/json/version`, maxAttempts, retryInterval)
-      ).webSocketDebuggerUrl;
+      webSocketUris = await Promise.all(
+        Array.from({ length: workersCount }, (_, i) => {
+          return contactChrome(`http://${ipAddress}:${workerExternalPort(i)}/json/version`, maxAttempts, retryInterval)
+            .then(r => r.webSocketDebuggerUrl as string)
+        })
+      )
 
-      return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUri: webSocketUri, headless: false };
+      return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUris, headless: false };
     } else {
+      if (workersCount > 1) {
+        throw new Error(`${CONSOLE_PREFIX} Headful mode does not support multiple workers (requested ${workersCount}). Use headless mode for parallel execution.`)
+      }
       // The problem that --remote-debugging-address is ignored in headful mode and we do not know how to forward 127.0.0.1 outside from a container
       // Links:
       //  * https://serverfault.com/questions/1132636/how-to-forward-inside-a-container-requests-from-0-0-0-0-to-127-0-0-1
@@ -126,18 +156,13 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
         `${isWindows ? "\"" : `'`}/bin/google-chrome ${preparedFlags.join(" ")} || exit $?${isWindows ? "\"" : `'`}`
       ])).out.trim();
 
-      await new Promise((res) => {
-        setTimeout(() => {
-          res(null)
-        }, 2000);
-      })
-
+      await waitForContainerRunning(chromeContainerId)
       const startLogs = (await runCommand(getDockerBinaryCLIPath(), [
         "logs",
         DOCKER_CONTAINER_NAME
       ])).err.trim();
 
-      webSocketUri = CDP_WEBSOCKET_ENDPOINT_REGEX.exec(startLogs)?.[1]
+      const webSocketUri = CDP_WEBSOCKET_ENDPOINT_REGEX.exec(startLogs)?.[1]
       if (!webSocketUri) {
         throw new Error(`${CONSOLE_PREFIX} 'webSocketUri' has not been calculated`);
       }
@@ -160,10 +185,10 @@ const dockerUp = async (flags: ChromeArg[]): Promise<DockerUpResult> => {
       }
 
       console.log(green(`${CONSOLE_PREFIX} Successfully started Docker container ${chromeContainerId} with the IP address ${ipAddress} and gateway ${gateway}`));
-      webSocketUri = webSocketUri.replace("127.0.0.1", ipAddress)
+      const resolvedUri = webSocketUri.replace("127.0.0.1", ipAddress)
+      console.log(green(`${CONSOLE_PREFIX} Connected to WebSocket URL: ${resolvedUri}`));
+      return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUris: [resolvedUri], headless: false };
     }
-    console.log(green(`${CONSOLE_PREFIX} Connected to WebSocket URL: ${webSocketUri}`));
-    return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUri: webSocketUri, headless: false };
   } catch (error) {
     console.error(error)
     throw new Error(`${CONSOLE_PREFIX} Failed to start Docker container \n\nInternal Error: \n\n${error}`);
@@ -251,9 +276,9 @@ export async function dockerShutdownChrome() {
   await dockerDown();
 }
 
-export async function dockerRunChrome({ flags }: { flags: ChromeArg[] }) {
+export async function dockerRunChrome({ flags, workersCount = 1 }: { flags: ChromeArg[], workersCount?: number }) {
   await dockerDown();
-  const {/*ipAddress, */hostIpAddress, webSocketUri, headless } = await dockerUp(flags);
-  return { webSocketUri: webSocketUri, hostIpAddress: hostIpAddress, headless: headless };
+  const { hostIpAddress, webSocketUris, headless } = await dockerUp(flags, workersCount);
+  return { webSocketUris, hostIpAddress, headless };
 };
 

--- a/src/lib/core/docker-chrome.ts
+++ b/src/lib/core/docker-chrome.ts
@@ -116,7 +116,7 @@ const dockerUp = async (flags: ChromeArg[], workersCount: number): Promise<Docke
         })
       )
 
-      return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUris, headless: false };
+      return { containerId: chromeContainerId, ipAddress: ipAddress, hostIpAddress: gateway, webSocketUris, headless: true };
     } else {
       if (workersCount > 1) {
         throw new Error(`${CONSOLE_PREFIX} Headful mode does not support multiple workers (requested ${workersCount}). Use headless mode for parallel execution.`)
@@ -269,7 +269,6 @@ const contactChrome = async (uri: string, maxAttempts: number, retryDelay: numbe
     return response.json();
   })
 }
-  ;
 
 export async function dockerShutdownChrome() {
   await killChrome();

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -21,7 +21,7 @@ import findNodeModules from "find-node-modules"
 
 import colors from "colors";
 import type { ChromeArg, JestPuppeteerConfig } from "../index.types"
-import { CHROME_INTERNAL_PORT, CHROME_PORT, CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
+import { CHROME_INTERNAL_PORT, CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
 
 const {bgYellow, black, yellow} = colors;
 

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -180,7 +180,6 @@ export async function initPuppeteerWithLocalChromeConfig() {
         )),
         connect: {
             args: [],
-            browserWSEndpoint: "NOT_INITIALIZED_YET_SHOULD_VE_SET_AFTER_CHROME_IS_STARTED"
         }
     }
     mergedConfig.launch.defaultViewport = mergedConfig.launch?.defaultViewport || null;

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -21,7 +21,7 @@ import findNodeModules from "find-node-modules"
 
 import colors from "colors";
 import type { ChromeArg, JestPuppeteerConfig } from "../index.types"
-import { CHROME_PORT, CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
+import { CHROME_INTERNAL_PORT, CHROME_PORT, CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
 
 const {bgYellow, black, yellow} = colors;
 
@@ -158,7 +158,7 @@ export async function initPuppeteerWithChromeInDockerConfig(): Promise<JestPuppe
         }
     }
     setChromeArgs(mergedConfig, "connect")
-    mergedConfig.connect.args.push("--remote-debugging-address=0.0.0.0", `--remote-debugging-port=${CHROME_PORT}`)
+    mergedConfig.connect.args.push("--remote-debugging-address=0.0.0.0", `--remote-debugging-port=${CHROME_INTERNAL_PORT}`)
     setAutoOpenDevtoolsForTabsFromLaunch(mergedConfig)
     setSowMoFromLaunch(mergedConfig)
     setProtocolTimeout(mergedConfig)

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -21,7 +21,7 @@ import findNodeModules from "find-node-modules"
 
 import colors from "colors";
 import type { ChromeArg, JestPuppeteerConfig } from "../index.types"
-import { CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
+import { CHROME_PORT, CONSOLE_PREFIX, DEFAULT_CHROME_FLAGS, DEFAULT_PROTOCOL_TIMEOUT } from "./defaults"
 
 const {bgYellow, black, yellow} = colors;
 
@@ -158,6 +158,7 @@ export async function initPuppeteerWithChromeInDockerConfig(): Promise<JestPuppe
         }
     }
     setChromeArgs(mergedConfig, "connect")
+    mergedConfig.connect.args.push("--remote-debugging-address=0.0.0.0", `--remote-debugging-port=${CHROME_PORT}`)
     setAutoOpenDevtoolsForTabsFromLaunch(mergedConfig)
     setSowMoFromLaunch(mergedConfig)
     setProtocolTimeout(mergedConfig)

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -158,7 +158,7 @@ export async function initPuppeteerWithChromeInDockerConfig(): Promise<JestPuppe
         }
     }
     setChromeArgs(mergedConfig, "connect")
-    mergedConfig.connect.args.push("--remote-debugging-address=0.0.0.0", `--remote-debugging-port=${CHROME_INTERNAL_PORT}`)
+    mergedConfig.connect.args.push(`--remote-debugging-port=${CHROME_INTERNAL_PORT}`)
     setAutoOpenDevtoolsForTabsFromLaunch(mergedConfig)
     setSowMoFromLaunch(mergedConfig)
     setProtocolTimeout(mergedConfig)

--- a/src/lib/core/read-jest-puppeteer-config.ts
+++ b/src/lib/core/read-jest-puppeteer-config.ts
@@ -183,6 +183,11 @@ export async function initPuppeteerWithLocalChromeConfig() {
         }
     }
     mergedConfig.launch.defaultViewport = mergedConfig.launch?.defaultViewport || null;
+    // Puppeteer 24+ no longer auto-discovers system Chrome when PUPPETEER_SKIP_DOWNLOAD is set.
+    // See https://pptr.dev/troubleshooting#chrome-is-downloaded-but-fails-to-launch
+    if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+        mergedConfig.launch.executablePath = process.env.PUPPETEER_EXECUTABLE_PATH
+    }
     setChromeArgs(mergedConfig, "launch")
     // @ts-ignore
     delete mergedConfig["connect"]

--- a/src/lib/env/setup.ts
+++ b/src/lib/env/setup.ts
@@ -33,16 +33,16 @@ export default async function (jestConfig: Config.ProjectConfig & Config.Argv) {
         await enableRunInDockerTeardownOnSignals()
 
         const puppeteerConfig = await initPuppeteerWithChromeInDockerConfig()
-        const {webSocketUri, hostIpAddress/*, headless*/} = await dockerRunChrome({flags: puppeteerConfig.connect.args});
-        await setBrowserWSEndpoint(webSocketUri)
+        const workersCount = Number(jestConfig.maxWorkers ?? 2);
+        const {webSocketUris, hostIpAddress} = await dockerRunChrome({flags: puppeteerConfig.connect.args, workersCount});
+        // Write first endpoint to config file for dumpPuppeteerConfig() diagnostics; workers use PUPPETEER_WS_ENDPOINTS env var
+        await setBrowserWSEndpoint(webSocketUris[0])
 
         // jest-environment-puppeteer v11 throws "Cannot use connect.browserWSEndpoint with multiple workers"
-        // in startBrowsers(). This is overly restrictive — CDP supports multiple simultaneous clients
-        // on one browser, each working in isolated targets. We set the env vars that workers need
-        // directly, bypassing setupPuppeteer() and its startBrowsers() entirely.
-        const workersCount = jestConfig.maxWorkers ?? 2;
+        // in startBrowsers(). We launch N Chrome processes (one per worker) in a single container
+        // and set the env vars that workers need directly, bypassing setupPuppeteer() entirely.
         process.env.WORKERS_COUNT = `${workersCount}`;
-        process.env.PUPPETEER_WS_ENDPOINTS = JSON.stringify(Array(Number(workersCount)).fill(webSocketUri));
+        process.env.PUPPETEER_WS_ENDPOINTS = JSON.stringify(webSocketUris);
 
         process.env.HOST_ADDRESS = hostIpAddress;
         console.log(bgYellow(black(`\n${CONSOLE_PREFIX} Local server address is ${process.env.HOST_ADDRESS}\n`)));

--- a/src/lib/env/setup.ts
+++ b/src/lib/env/setup.ts
@@ -35,8 +35,15 @@ export default async function (jestConfig: Config.ProjectConfig & Config.Argv) {
         const puppeteerConfig = await initPuppeteerWithChromeInDockerConfig()
         const {webSocketUri, hostIpAddress/*, headless*/} = await dockerRunChrome({flags: puppeteerConfig.connect.args});
         await setBrowserWSEndpoint(webSocketUri)
-        // fixme: https://github.com/argos-ci/jest-puppeteer/discussions/577
-        process.env.WORKERS_COUNT = `${jestConfig.maxWorkers ?? 2}`;
+
+        // jest-environment-puppeteer v11 throws "Cannot use connect.browserWSEndpoint with multiple workers"
+        // in startBrowsers(). This is overly restrictive — CDP supports multiple simultaneous clients
+        // on one browser, each working in isolated targets. We set the env vars that workers need
+        // directly, bypassing setupPuppeteer() and its startBrowsers() entirely.
+        const workersCount = jestConfig.maxWorkers ?? 2;
+        process.env.WORKERS_COUNT = `${workersCount}`;
+        process.env.PUPPETEER_WS_ENDPOINTS = JSON.stringify(Array(Number(workersCount)).fill(webSocketUri));
+
         process.env.HOST_ADDRESS = hostIpAddress;
         console.log(bgYellow(black(`\n${CONSOLE_PREFIX} Local server address is ${process.env.HOST_ADDRESS}\n`)));
         process.env.PUPPETEER_SKIP_DOWNLOAD = process.env.PUPPETEER_SKIP_DOWNLOAD ?? "false";
@@ -45,7 +52,6 @@ export default async function (jestConfig: Config.ProjectConfig & Config.Argv) {
         console.log(bgYellow(black(`\n${CONSOLE_PREFIX} Run on host\n`)));
         await initPuppeteerWithLocalChromeConfig()
         dumpPuppeteerConfig()
-
+        await setupPuppeteer(jestConfig);
     }
-    await setupPuppeteer(jestConfig);
 };

--- a/src/lib/index.types.ts
+++ b/src/lib/index.types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ConnectOptions, PuppeteerLaunchOptions } from "puppeteer"
+import { ConnectOptions, LaunchOptions } from "puppeteer"
 
 export type ChromeArg = `--${string}`
-export type JestPuppeteerConfig = {launch: PuppeteerLaunchOptions & {args: ChromeArg[]}} & {connect: ConnectOptions & {args: ChromeArg[]}}
+export type JestPuppeteerConfig = {launch: LaunchOptions & {args: ChromeArg[]}} & {connect: ConnectOptions & {args: ChromeArg[]}}


### PR DESCRIPTION
## Summary   
 Support Node.js 24, Puppeteer 24, and jest-environment-puppeteer 11 in Docker-based screenshot testing mode. Launch N Chrome instances (one per Jest worker) inside a single container for parallel test execution at near-CI performance.                                                                      
                                                                                                                                                                                                                                                                                                                    
  ## What changed                 
                                                                                                                                                                                                                                                                                                                    
  ### Chrome 113+ headless fix (socat proxy)
                                                                                                                                                                                                                                                                                                                    
  Chrome 113+ silently ignores `--remote-debugging-address=0.0.0.0` for security reasons, always binding to `127.0.0.1`. This makes the DevTools port inaccessible from outside the container.

  **Fix:** Each Chrome listens on `127.0.0.1:<internalPort>`, and a socat process forwards `0.0.0.0:<externalPort>` → `127.0.0.1:<internalPort>`. Docker/Podman maps the external port to the host.

  ### Multi-Chrome parallel workers

  jest-environment-puppeteer 11 enforces one browser per worker and throws `"Cannot use connect.browserWSEndpoint with multiple workers"` when using `connect` mode. Previously, Docker mode ran a single Chrome shared across all workers, limiting `maxWorkers` to 1.

  **Fix:** Launch N Chrome processes (one per worker) inside a single container, each with:
  - Dedicated port pair (external for socat, internal for Chrome): 9222/9223, 9224/9225, 9226/9227, ...
  - Isolated `--user-data-dir=/tmp/chrome-profile-<i>` to prevent profile conflicts

  In `globalSetup`, bypass `setupPuppeteer()` entirely and set `WORKERS_COUNT` + `PUPPETEER_WS_ENDPOINTS` env vars directly — workers pick up their assigned WebSocket endpoint from the array.

  ### Other changes

  - **`waitForContainerRunning()`** — polls `podman inspect` for container `running` state instead of a hardcoded `setTimeout(2000)`
  - **`workerExternalPort(i)` / `workerInternalPort(i)`** — extracted port allocation helpers for clarity
  - **Headful mode validation** — throws early if `workersCount > 1` (headful cannot expose multiple debug ports)
  - **Puppeteer 24 compatibility** — `executablePath` from `PUPPETEER_EXECUTABLE_PATH` env var (Puppeteer 24 no longer auto-discovers system Chrome)
  - **peerDependencies** — `jest-environment-puppeteer: ">= 11.0.0"`, `puppeteer: ">= 22.0.0"`

  ## Performance results

  **api-doc-viewer (14 suites, 237 tests):**

  | Mode | Time |
  |---|---|
  | Docker, 1 Chrome, 1 worker | 410s |
  | Docker, 4 Chrome, 4 workers | **131s** |
  | CI, 4 Chrome local (launch mode) | 107s |

  **apispec-view (47 suites, 795 tests):**

  | Mode | Time |
  |---|---|
  | Docker, 1 Chrome, 1 worker | 2118s |
  | Docker, 4 Chrome, 4 workers | **717s** |
  | CI, 4 Chrome local (launch mode) | 1339s |

  ## Test plan

  - [x] api-doc-viewer: 14 suites, 237 tests PASS (maxWorkers 4, docker mode)
  - [x] apispec-view: 47 suites, 795 tests PASS (maxWorkers 4, docker mode)
  - [x] TypeScript compilation clean
  - [x] Headful mode with 1 worker still works
  - [x] Headful mode with >1 worker throws clear error
